### PR TITLE
feat: add confirmation dialog when deleting an item

### DIFF
--- a/app/src/main/java/pl/edu/pjwstk/s999844/shoppinglist/activities/MainActivity.kt
+++ b/app/src/main/java/pl/edu/pjwstk/s999844/shoppinglist/activities/MainActivity.kt
@@ -98,6 +98,7 @@ class MainActivity : AbstractShoppingActivity() {
 			?: return
 
 		if (change == null) {
+		if (settings.deleteConfirmationActive) {
 			AlertDialog.Builder(this).apply {
 				setTitle(R.string.deleteConfirmTitle)
 				setMessage(getString(R.string.deleteConfirmMessage, dbItem.name))
@@ -106,6 +107,9 @@ class MainActivity : AbstractShoppingActivity() {
 				}
 				setNegativeButton(R.string.deleteConfirmNoButton, null)
 				show()
+			}
+		} else {
+			shoppingListDao.delete(dbItem)
 			}
 		} else {
 			dbItem.amount = change.plus(dbItem.amount).coerceAtLeast(0)

--- a/app/src/main/java/pl/edu/pjwstk/s999844/shoppinglist/activities/MainActivity.kt
+++ b/app/src/main/java/pl/edu/pjwstk/s999844/shoppinglist/activities/MainActivity.kt
@@ -31,6 +31,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -97,7 +98,15 @@ class MainActivity : AbstractShoppingActivity() {
 			?: return
 
 		if (change == null) {
-			shoppingListDao.delete(dbItem)
+			AlertDialog.Builder(this).apply {
+				setTitle(R.string.deleteConfirmTitle)
+				setMessage(getString(R.string.deleteConfirmMessage, dbItem.name))
+				setPositiveButton(R.string.deleteConfirmYesButton) { _, _ ->
+					shoppingListDao.delete(dbItem)
+				}
+				setNegativeButton(R.string.deleteConfirmNoButton, null)
+				show()
+			}
 		} else {
 			dbItem.amount = change.plus(dbItem.amount).coerceAtLeast(0)
 			shoppingListDao.update(dbItem)

--- a/app/src/main/java/pl/edu/pjwstk/s999844/shoppinglist/activities/OptionsActivity.kt
+++ b/app/src/main/java/pl/edu/pjwstk/s999844/shoppinglist/activities/OptionsActivity.kt
@@ -86,6 +86,7 @@ class OptionsActivity : AbstractShoppingActivity() {
 		binding.listOrderDropdown.setSelection(getIndex(binding.listOrderDropdown, settings.order))
 		binding.accentColorDropdown.setSelection(getIndex(binding.accentColorDropdown, settings.accentColor))
 		binding.optionsOrderZeroItemsLastSwitch.isChecked = settings.orderZeroItemsLast
+		binding.optionsDeleteConfirmationSwitch.isChecked = settings.deleteConfirmationActive
 
 		title = getString(R.string.optionsTitleBarText)
 	}
@@ -100,6 +101,11 @@ class OptionsActivity : AbstractShoppingActivity() {
 	@Suppress("UNUSED_PARAMETER")
 	fun onClickOrderZeroItemsLastSwitch(view: View) {
 		settings.orderZeroItemsLast = binding.optionsOrderZeroItemsLastSwitch.isChecked
+	}
+
+	@Suppress("UNUSED_PARAMETER")
+	fun onClickDeleteConfirmationSwitch(view: View) {
+		settings.deleteConfirmationActive = binding.optionsDeleteConfirmationSwitch.isChecked
 	}
 
 	@Suppress("UNUSED_PARAMETER")

--- a/app/src/main/java/pl/edu/pjwstk/s999844/shoppinglist/settings/Settings.kt
+++ b/app/src/main/java/pl/edu/pjwstk/s999844/shoppinglist/settings/Settings.kt
@@ -44,6 +44,9 @@ class Settings(context: Context) {
 
 		private const val ORDER_ZERO_ITEMS_LAST_NAME = "orderZeroItemsLast"
 		private const val ORDER_ZERO_ITEMS_LAST_DEFAULT = true
+
+		private const val DELETE_CONFIRMATION_NAME = "deleteConfirmation"
+		private const val DELETE_CONFIRMATION_DEFAULT = false
 	}
 
 	private val sharedPreferences: SharedPreferences = context.getSharedPreferences("SETTINGS", MODE_PRIVATE)
@@ -75,6 +78,10 @@ class Settings(context: Context) {
 	var orderZeroItemsLast: Boolean
 		get() = sharedPreferences.getBoolean(ORDER_ZERO_ITEMS_LAST_NAME, ORDER_ZERO_ITEMS_LAST_DEFAULT)
 		set(value) = edit().putBoolean(ORDER_ZERO_ITEMS_LAST_NAME, value).apply()
+
+	var deleteConfirmationActive: Boolean
+		get() = sharedPreferences.getBoolean(DELETE_CONFIRMATION_NAME, DELETE_CONFIRMATION_DEFAULT)
+		set(value) = edit().putBoolean(DELETE_CONFIRMATION_NAME, value).apply()
 
 	interface DescriptiveSetting {
 		val descriptionResourceId: Int

--- a/app/src/main/res/layout/activity_options.xml
+++ b/app/src/main/res/layout/activity_options.xml
@@ -95,6 +95,16 @@
 		app:layout_constraintStart_toStartOf="parent"
 		app:layout_constraintEnd_toEndOf="parent" />
 
+	<androidx.appcompat.widget.SwitchCompat
+		android:id="@+id/optionsDeleteConfirmationSwitch"
+		style="@style/Theme.ShoppingList.SwitchCompat"
+		android:onClick="onClickDeleteConfirmationSwitch"
+		android:text="@string/optionsDeleteConfirmationText"
+		android:textSize="@dimen/optionTextSize"
+		app:layout_constraintTop_toBottomOf="@id/optionsOrderZeroItemsLastSwitch"
+		app:layout_constraintStart_toStartOf="parent"
+		app:layout_constraintEnd_toEndOf="parent" />
+
 	<LinearLayout
 		android:layout_width="wrap_content"
 		android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,4 +63,6 @@
 	<string name="deleteConfirmMessage" comment="This text will be shown as the message of the delete confirmation dialog" formatted="true">Are you sure you want to delete %1$s?</string>
 	<string name="deleteConfirmYesButton" comment="This text will be shown on the confirm button of the delete confirmation dialog">Yes</string>
 	<string name="deleteConfirmNoButton" comment="This text will be shown on the cancel button of the delete confirmation dialog">No</string>
+
+	<string name="optionsDeleteConfirmationText" comment="This text will be shown in the options menu as description for the delete confirmation switch">Ask before deleting items</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,4 +58,9 @@
 	<string name="addItemAlreadyExistsMessage" comment="This text will be shown if a user tries to add the same item multiple times">An item with this name already exists</string>
 	<string name="addShareButtonText" comment="This text will be shown on the share-button when adding a new item">Send</string>
 	<string name="addShareText" comment="This text will be sent to your contact when sharing a new item with them" formatted="true">Please add an item to your shopping list: %1$s</string>
+
+	<string name="deleteConfirmTitle" comment="This text will be shown as the title of the delete confirmation dialog">Delete item</string>
+	<string name="deleteConfirmMessage" comment="This text will be shown as the message of the delete confirmation dialog" formatted="true">Are you sure you want to delete %1$s?</string>
+	<string name="deleteConfirmYesButton" comment="This text will be shown on the confirm button of the delete confirmation dialog">Yes</string>
+	<string name="deleteConfirmNoButton" comment="This text will be shown on the cancel button of the delete confirmation dialog">No</string>
 </resources>


### PR DESCRIPTION
## Checklist

- [x] I read and understood the **[Contributing Guidelines](https://github.com/Abrynos/ShoppingList/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/Abrynos/ShoppingList/pulls)** of an existing merge request.
- [x] This is not a **[translation update](https://crowdin.com/project/abrynosshoppinglist)**.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/Abrynos/ShoppingList/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] All new and existing tests pass.

## Changes

When an item was deleted, no confirmation would appear.
The item was directly deleted.
Now, when an item is going to be deleted, a confirmation dialog will appear.

This should mark as complete #123 

### New functionality

A new confirmation dialog will appear when an item is going to be deleted from the list.

## Notes and comments

I really love this application and thank you for developing it :smile: 
It's the only one as simple as a pen and piece of paper could be.

### AI disclosure

All changes were completely vibecoded. I have no Kotlin/Android knowledge.
But I extensively tested the correct behavior of all changes.
I'm really sorry for any stupid piece of code that could be there.
**Tools used:** VSCode, Kilocode extension, llama.cpp, Qwen3.5-27B