### PR TITLE
feat: add possibility to mark item as purchased

### DIFF
--- a/app/src/main/java/pl/edu/pjwstk/s999844/shoppinglist/activities/MainActivity.kt
+++ b/app/src/main/java/pl/edu/pjwstk/s999844/shoppinglist/activities/MainActivity.kt
@@ -57,7 +57,6 @@ class MainActivity : AbstractShoppingActivity() {
 		binding.mainListRecyclerView.addItemDecoration(DividerItemDecoration(this, DividerItemDecoration.VERTICAL))
 
 		shoppingListDao.findAllItems().observe(this, this::observeDatabaseChange)
-		binding.mainListRecyclerView.adapter = ShoppingListAdapter(this::changeItemCallback)
 	}
 
 	override fun onStart() {
@@ -86,6 +85,16 @@ class MainActivity : AbstractShoppingActivity() {
 
 	@Suppress("UNUSED_PARAMETER")
 	fun onClickFloatingButton(view: View) = startActivity(Intent(baseContext, AddItemActivity::class.java))
+
+	/**
+	 * Toggle the purchased state of an item.
+	 */
+	private fun togglePurchasedCallback(item: RequiredItem) {
+		val dbItem: RequiredItem = shoppingListDao.findById(item.id)
+			?: return
+		dbItem.purchased = !dbItem.purchased
+		shoppingListDao.update(dbItem)
+	}
 
 	/**
 	 * Update item's amount.
@@ -135,7 +144,9 @@ class MainActivity : AbstractShoppingActivity() {
 		}
 
 		val sorted = items.sortedWith(comparator)
-		(binding.mainListRecyclerView.adapter as ShoppingListAdapter).setItems(sorted)
+		val adapter = ShoppingListAdapter(this::changeItemCallback, this::togglePurchasedCallback, settings.strikethroughPurchased)
+		adapter.setItems(sorted)
+		binding.mainListRecyclerView.adapter = adapter
 
 		binding.mainEmptyTextView.isVisible = items.isEmpty()
 		binding.mainListRecyclerView.isVisible = items.isNotEmpty()

--- a/app/src/main/java/pl/edu/pjwstk/s999844/shoppinglist/activities/OptionsActivity.kt
+++ b/app/src/main/java/pl/edu/pjwstk/s999844/shoppinglist/activities/OptionsActivity.kt
@@ -87,6 +87,7 @@ class OptionsActivity : AbstractShoppingActivity() {
 		binding.accentColorDropdown.setSelection(getIndex(binding.accentColorDropdown, settings.accentColor))
 		binding.optionsOrderZeroItemsLastSwitch.isChecked = settings.orderZeroItemsLast
 		binding.optionsConfirmDeletionSwitch.isChecked = settings.confirmDeletion
+		binding.optionsStrikethroughSwitch.isChecked = settings.strikethroughPurchased
 
 		title = getString(R.string.optionsTitleBarText)
 	}
@@ -106,6 +107,11 @@ class OptionsActivity : AbstractShoppingActivity() {
 	@Suppress("UNUSED_PARAMETER")
 	fun onClickConfirmDeletionSwitch(view: View) {
 		settings.confirmDeletion = binding.optionsConfirmDeletionSwitch.isChecked
+	}
+
+	@Suppress("UNUSED_PARAMETER")
+	fun onClickStrikethroughSwitch(view: View) {
+		settings.strikethroughPurchased = binding.optionsStrikethroughSwitch.isChecked
 	}
 
 	@Suppress("UNUSED_PARAMETER")

--- a/app/src/main/java/pl/edu/pjwstk/s999844/shoppinglist/adapters/ShoppingListAdapter.kt
+++ b/app/src/main/java/pl/edu/pjwstk/s999844/shoppinglist/adapters/ShoppingListAdapter.kt
@@ -27,6 +27,7 @@
 package pl.edu.pjwstk.s999844.shoppinglist.adapters
 
 import android.annotation.SuppressLint
+import android.graphics.Paint
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.view.isVisible
@@ -34,8 +35,13 @@ import androidx.recyclerview.widget.RecyclerView
 import pl.edu.pjwstk.s999844.shoppinglist.databinding.ShoppingListItemBinding
 import pl.edu.pjwstk.s999844.shoppinglist.models.RequiredItem
 import java.util.function.BiConsumer
+import java.util.function.Consumer
 
-class ShoppingListAdapter(private val changeAmountCallback: BiConsumer<RequiredItem, Int?>) : RecyclerView.Adapter<ShoppingListAdapter.ViewHolder>() {
+class ShoppingListAdapter(
+	private val changeAmountCallback: BiConsumer<RequiredItem, Int?>,
+	private val togglePurchasedCallback: Consumer<RequiredItem>,
+	private val featureActive: Boolean
+) : RecyclerView.Adapter<ShoppingListAdapter.ViewHolder>() {
 	companion object {
 		private const val ZERO_ITEMS_OPACITY = 0.3f
 	}
@@ -56,7 +62,19 @@ class ShoppingListAdapter(private val changeAmountCallback: BiConsumer<RequiredI
 		binding.amountTextView.isVisible = item.amount > 1
 
 		binding.nameTextView.text = item.name
-		binding.nameTextView.alpha = if (item.amount > 0) 1f else ZERO_ITEMS_OPACITY
+
+		val isPurchased = featureActive && item.purchased
+		val flags = if (isPurchased) binding.nameTextView.paintFlags or Paint.STRIKE_THRU_TEXT_FLAG else binding.nameTextView.paintFlags and Paint.STRIKE_THRU_TEXT_FLAG.inv()
+		binding.nameTextView.paintFlags = flags
+		binding.nameTextView.alpha = if (isPurchased) ZERO_ITEMS_OPACITY else if (item.amount > 0) 1f else ZERO_ITEMS_OPACITY
+
+		if (featureActive) {
+			binding.root.setOnClickListener {
+				togglePurchasedCallback.accept(item)
+			}
+		} else {
+			binding.root.setOnClickListener(null)
+		}
 
 		binding.addButton.setOnClickListener {
 			changeAmountCallback.accept(item, 1)

--- a/app/src/main/java/pl/edu/pjwstk/s999844/shoppinglist/dal/ShoppingListDatabase.kt
+++ b/app/src/main/java/pl/edu/pjwstk/s999844/shoppinglist/dal/ShoppingListDatabase.kt
@@ -27,17 +27,27 @@
 package pl.edu.pjwstk.s999844.shoppinglist.dal
 
 import android.content.Context
+
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
 import pl.edu.pjwstk.s999844.shoppinglist.models.RequiredItem
 
-@Database(entities = [RequiredItem::class], version = 1, exportSchema = false)
+@Database(entities = [RequiredItem::class], version = 2, exportSchema = false)
 abstract class ShoppingListDatabase : RoomDatabase() {
 	abstract fun getShoppingListDao(): ShoppingListDao
 
 	@Suppress("SyntheticAccessor")
 	companion object {
+		private val MIGRATION_1_2 = object : Migration(1, 2) {
+			override fun migrate(db: SupportSQLiteDatabase) {
+				db.execSQL("ALTER TABLE RequiredItem ADD COLUMN purchased INTEGER NOT NULL DEFAULT 0")
+			}
+		}
+
 		private var INSTANCE: ShoppingListDatabase? = null
 
 		fun getInstance(context: Context): ShoppingListDatabase {
@@ -48,6 +58,7 @@ abstract class ShoppingListDatabase : RoomDatabase() {
 
 			instance = Room.databaseBuilder(context.applicationContext, ShoppingListDatabase::class.java, ShoppingListDatabase::class.java.name)
 				.allowMainThreadQueries()
+				.addMigrations(MIGRATION_1_2)
 				.build()
 			INSTANCE = instance
 			return instance

--- a/app/src/main/java/pl/edu/pjwstk/s999844/shoppinglist/models/RequiredItem.kt
+++ b/app/src/main/java/pl/edu/pjwstk/s999844/shoppinglist/models/RequiredItem.kt
@@ -34,6 +34,8 @@ class RequiredItem(var name: String, var amount: Int) {
 	@PrimaryKey(autoGenerate = true)
 	var id: Long = 0
 
+	var purchased: Boolean = false
+
 	override fun equals(other: Any?): Boolean {
 		if (this === other) return true
 		if (javaClass != other?.javaClass) return false

--- a/app/src/main/java/pl/edu/pjwstk/s999844/shoppinglist/settings/Settings.kt
+++ b/app/src/main/java/pl/edu/pjwstk/s999844/shoppinglist/settings/Settings.kt
@@ -47,6 +47,9 @@ class Settings(context: Context) {
 
 		private const val ORDER_ZERO_ITEMS_LAST_NAME = "orderZeroItemsLast"
 		private const val ORDER_ZERO_ITEMS_LAST_DEFAULT = true
+
+		private const val STRIKETHROUGH_PURCHASED_NAME = "strikethroughPurchased"
+		private const val STRIKETHROUGH_PURCHASED_DEFAULT = false
 	}
 
 	private val sharedPreferences: SharedPreferences = context.getSharedPreferences("SETTINGS", MODE_PRIVATE)
@@ -82,6 +85,10 @@ class Settings(context: Context) {
 	var orderZeroItemsLast: Boolean
 		get() = sharedPreferences.getBoolean(ORDER_ZERO_ITEMS_LAST_NAME, ORDER_ZERO_ITEMS_LAST_DEFAULT)
 		set(value) = edit().putBoolean(ORDER_ZERO_ITEMS_LAST_NAME, value).apply()
+
+	var strikethroughPurchased: Boolean
+		get() = sharedPreferences.getBoolean(STRIKETHROUGH_PURCHASED_NAME, STRIKETHROUGH_PURCHASED_DEFAULT)
+		set(value) = edit().putBoolean(STRIKETHROUGH_PURCHASED_NAME, value).apply()
 
 	interface DescriptiveSetting {
 		val descriptionResourceId: Int

--- a/app/src/main/res/layout/activity_options.xml
+++ b/app/src/main/res/layout/activity_options.xml
@@ -105,6 +105,16 @@
 		app:layout_constraintStart_toStartOf="parent"
 		app:layout_constraintEnd_toEndOf="parent" />
 
+	<androidx.appcompat.widget.SwitchCompat
+		android:id="@+id/optionsStrikethroughSwitch"
+		style="@style/Theme.ShoppingList.SwitchCompat"
+		android:onClick="onClickStrikethroughSwitch"
+		android:text="@string/optionsStrikethroughPurchasedText"
+		android:textSize="@dimen/optionTextSize"
+		app:layout_constraintTop_toBottomOf="@id/optionsConfirmDeletionSwitch"
+		app:layout_constraintStart_toStartOf="parent"
+		app:layout_constraintEnd_toEndOf="parent" />
+
 	<LinearLayout
 		android:layout_width="wrap_content"
 		android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
 
 	<string name="optionsUseDarkThemeText" comment="This text will be shown in the options menu as description for the theme switch">Use dark theme</string>
 	<string name="optionsOrderZeroItemsLastText" comment="This text will be shown in the options menu as description for the switch for sorting zero-count items last">Order zero-count items last</string>
+	<string name="optionsStrikethroughPurchasedText" comment="This text will be shown in the options menu as description for the switch to mark purchased items">Tap item to mark as purchased</string>
 	<string name="optionsTitleBarText" comment="This text will be shown in the options menus titlebar">Options</string>
 	<string name="optionsLatestReleaseText" comment="This text will be shown in the options menu as the link to the lastest release">latest release</string>
 	<string name="optionsListOrderText" comment="This text will be shown in the options menu as description of the dropdown for sorting the shopping list">Order</string>


### PR DESCRIPTION
## Checklist

- [x] I read and understood the **[Contributing Guidelines](https://github.com/Abrynos/ShoppingList/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/Abrynos/ShoppingList/pulls)** of an existing merge request.
- [x] This is not a **[translation update](https://crowdin.com/project/abrynosshoppinglist)**.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/Abrynos/ShoppingList/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] All new and existing tests pass.

## Changes

### New functionality

When setting is enabled, tapping on an item will make the text strikethrough, ideally marking that item as purchased/completed.
Disabling the setting will remove any strikethrough but keep the state, so when enabled again, items will be marked again as before.

This should mark as completed: #44, #51, #158 and other

<details>
    <summary>Screenshots</summary>
    <img width="602" height="1280" alt="Screen_1" src="https://github.com/user-attachments/assets/fc92b206-17b8-4171-8372-dfbca9d01070" />
    <img width="604" height="1280" alt="Screen_2" src="https://github.com/user-attachments/assets/bc11f035-34e3-4766-9b31-94579612c56e" />
</details>

## AI disclosure

All changes were completely vibecoded. I have no Kotlin/Android knowledge.
But I extensively tested the correct behavior of all changes.
I'm really sorry for any stupid piece of code that could be there.
**Tools used:** VSCodium, Kilocode extension, llama.cpp, Qwen3.5-27B